### PR TITLE
build(makefile): Add suppression flags to cpp check to improve speed and

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,9 @@ CPPCHECK_INCLUDES = \
 CPPCHECK_FLAGS = \
 	--quiet --enable=all --error-exitcode=1 \
 	--inline-suppr \
+	--suppress=missingIncludeSystem \
+	--suppress=unmatchedSuppression \
+	--suppress=unusedFunction \
 	$(addprefix -I,$(CPPCHECK_INCLUDES)) 	
 
 


### PR DESCRIPTION
prevent unwanted errors

Include supression flags for unused functions, not included files and unmatched supression. These flags will help prevent unwanted errors during cpp checks and also improve the speed of the check during the CI process.