### PR TITLE
feat(assert): Assert handler to make asserts in functions to alert for

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,8 @@ C_SOURCES =  \
 	Src/app/enemy.c \
 	Src/drivers/io.c \
 	Src/drivers/mcu_init.c \
+	Src/drivers/led.c \
+	Src/common/assert_handler.c \
 	Src/system_stm32l4xx.c \
 
 C_SOURCES_WITH_HEADERS = \
@@ -57,6 +59,8 @@ C_SOURCES_WITH_HEADERS = \
 	Src/app/enemy.c \
 	Src/drivers/io.c \
 	Src/drivers/mcu_init.c \
+	Src/drivers/led.c \
+	Src/common/assert_handler.c \
 
 CPP_CHECK_C_SOURCES =  \
 	Src/main.c \

--- a/Makefile
+++ b/Makefile
@@ -142,7 +142,7 @@ C_INCLUDES =  \
 # compile gcc flags
 ASFLAGS = $(MCU) $(AS_DEFS) $(AS_INCLUDES) $(OPT) -Wall -fdata-sections -ffunction-sections
 
-CFLAGS += $(MCU) $(C_DEFS) $(addprefix -I,$(C_INCLUDES)) $(OPT) -Wall -Wextra -Werror -fdata-sections -ffunction-sections
+CFLAGS += $(MCU) $(C_DEFS) $(addprefix -I,$(C_INCLUDES)) $(OPT) -fshort-enums -Wall -Wextra -Werror -fdata-sections -ffunction-sections
 
 ifeq ($(DEBUG), 1)
 CFLAGS += -g -gdwarf-2

--- a/Src/common/assert_handler.c
+++ b/Src/common/assert_handler.c
@@ -1,0 +1,26 @@
+#include "assert_handler.h"
+#include "defines.h"
+#include "stm32l4xx.h"
+
+#define BREAKPOINT __asm volatile("bkpt #0");
+
+void assert_handler(void)
+{
+    BREAKPOINT
+
+    /* Accessing registers directly to config TEST LED to prevent
+    calling functions that have assertions, this prevents recursive assertions*/
+    RCC->AHB2ENR |= 0x1;
+
+    GPIOA->MODER &= ~(0x3 << (2 * 5));
+    GPIOA->MODER |= (0x1 << (2 * 5));
+    GPIOA->OTYPER &= ~(0x1 << 5);
+    GPIOA->OSPEEDR &= ~(0x3 << (2 * 5));
+    GPIOA->OSPEEDR |= (0x3 << (2 * 5));
+
+    volatile int j;
+    while (1) {
+        GPIOA->ODR ^= (0x1 << 5);
+        BUSY_WAIT_ms(120)
+    };
+}

--- a/Src/common/assert_handler.h
+++ b/Src/common/assert_handler.h
@@ -1,0 +1,12 @@
+#ifndef ASSERT_HANDLER_H
+/* Assert on microcontroller to turn off motors during a fault*/
+#define ASSERT(expression)                                                                         \
+    do {                                                                                           \
+        if (!(expression)) {                                                                       \
+            assert_handler();                                                                      \
+        }                                                                                          \
+    } while (0)
+
+void assert_handler(void);
+
+#endif // ASSERT_HANDLER_H

--- a/Src/common/defines.h
+++ b/Src/common/defines.h
@@ -2,4 +2,11 @@
 #define DEFINES_H
 #define UNUSED(x) (void)(x)
 #define ARRAY_SIZE(array) (sizeof(array) / sizeof(array[0]))
+
+// STM32L3 runs at default 4MHz
+#define CLOCK_FREQ_4MZ (4000000U)
+#define CLOCK_FREQ_PER_ms (CLOCK_FREQ_4MZ / 1000U)
+#define BUSY_WAIT_ms(delay_ms)                                                                     \
+    for (j = (delay_ms * CLOCK_FREQ_PER_ms); j > 0; j--) {                                         \
+    }; // takes the count for how long you want to delay
 #endif

--- a/Src/drivers/io.c
+++ b/Src/drivers/io.c
@@ -2,17 +2,26 @@
 #include "../common/defines.h"
 #include "stdint.h"
 #include "stm32l4xx.h"
+#include <assert.h>
 
 /*
 - Use the bit pattern of the port enums assigned to the
 io_e pins to get their port and pin numbers
 - The pin number is represented by the last 4 bits of the bits (15 is the largest pin no)
 - The port number is represented by the 4 bits directly before the 4 pin bits
+- Enums are represented as 8 bytes using compiler flag -fshort-enums
 */
 #define IO_PORT_OFFSET (4U)
 #define IO_PORT_MASK (0xFu << IO_PORT_OFFSET)
 #define IO_PIN_MASK (0xFu)
-
+// To get rid of error squiggles since vscode intellisense thinks enums are 4bytes
+#if defined(__INTELLISENSE__)
+_Static_assert(sizeof(io_ports_e) == 4, "IntelliSense only: workaround");
+#else
+static_assert(sizeof(io_ports_e) == 1,
+              "Unexpected enum size"
+              "-fshort-enums missing?");
+#endif
 #define IO_PORT_CNT (3U)
 #define IO_PIN_CNT (48U)
 

--- a/Src/drivers/io.c
+++ b/Src/drivers/io.c
@@ -16,7 +16,6 @@ io_e pins to get their port and pin numbers
 #define IO_PORT_CNT (3U)
 #define IO_PIN_CNT (48U)
 
-
 /* Array holds the initial config for each pin
  * Configure unused pins as input with pull down resistors
  * Configure the pin to prevent unpredictable noise for floating pins   */
@@ -24,7 +23,6 @@ io_e pins to get their port and pin numbers
     {                                                                                              \
         IO_MODE_INPUT, IO_PORT_PD, IO_SPEED_LOW, IO_TYPE_PP                                        \
     }
-
 
 static const struct io_config io_pins_initial_configs[IO_PIN_CNT] = {
     // line detectors set up as analog input
@@ -295,3 +293,30 @@ io_in_e io_get_input(io_e io)
     const uint8_t input = GPIO->IDR & (0x1 << pin);
     return input ? IO_IN_HIGH : IO_IN_LOW;
 }
+void io_get_io_config(io_e io, struct io_config *current_config)
+{
+    const uint8_t pin = io_get_pin_idx(io);
+    const uint8_t port = io_get_port(io);
+
+    const GPIO_TypeDef *GPIO = gpio_port_regs[port];
+    current_config->mode = (io_mode_e)((GPIO->MODER & (0x3 << (2 * pin))) >> (2 * pin));
+    current_config->pupd = (io_pupd_e)((GPIO->PUPDR & (0x3 << (2 * pin))) >> (2 * pin));
+    current_config->speed = (io_ouput_speed_e)((GPIO->OSPEEDR & (0x3 << (2 * pin))) >> (2 * pin));
+    current_config->type = (io_out_type_e)((GPIO->OTYPER & (0x1 << pin)) >> pin);
+};
+bool io_compare_io_config(const struct io_config *config1, const struct io_config *config2)
+{
+    if (config1->mode != config2->mode) {
+        return false;
+    }
+    if (config1->pupd != config2->pupd) {
+        return false;
+    }
+    if (config1->speed != config2->speed) {
+        return false;
+    }
+    if (config1->type != config2->type) {
+        return false;
+    }
+    return true;
+};

--- a/Src/drivers/io.h
+++ b/Src/drivers/io.h
@@ -1,5 +1,6 @@
 #ifndef IO_H
 #define IO_H
+#include "stdbool.h"
 // ENUMS
 typedef enum
 {
@@ -166,6 +167,8 @@ struct io_config
 // FUNCTIONS
 void io_init(void);
 void io_configure(io_e io, const struct io_config *config);
+void io_get_io_config(io_e io, struct io_config *current_config);
+bool io_compare_io_config(const struct io_config *config1, const struct io_config *config2);
 void io_port_init(io_e io);
 void io_set_mode(io_e io, io_mode_e mode);
 void io_set_output_type(io_e io, io_out_type_e type);

--- a/Src/drivers/led.c
+++ b/Src/drivers/led.c
@@ -1,0 +1,31 @@
+#include "led.h"
+#include "assert_handler.h"
+#include "defines.h"
+#include "io.h"
+#include "stdbool.h"
+static bool initialized = false;
+static const struct io_config led_config = {
+    .mode = IO_MODE_OUPUT, .pupd = IO_NO_PUPD, .speed = IO_SPEED_VERY_HIGH, .type = IO_TYPE_PP
+};
+void led_init(void)
+{
+    /* First assert that led_init has not been called yet
+     * This is to prevent multiple calls to the function*/
+    ASSERT(!initialized);
+    struct io_config current_config;
+
+    io_get_io_config(IO_TEST_LED, &current_config);
+
+    ASSERT(io_compare_io_config(&current_config, &led_config));
+    initialized = true;
+};
+void led_set(led_e led, led_state_e state)
+{
+    ASSERT(initialized);
+    io_out_e out = state == LED_STATE_ON ? IO_OUT_HIGH : IO_OUT_LOW;
+    switch (led) {
+    case LED_TEST:
+        io_set_output(IO_TEST_LED, out);
+        break;
+    }
+};

--- a/Src/drivers/led.h
+++ b/Src/drivers/led.h
@@ -1,0 +1,17 @@
+#ifndef LED_H
+// Led driver to control the IO_TEST_LED pin and blink the led it is connected to
+#define LED_H
+
+typedef enum
+{
+    LED_TEST
+} led_e;
+typedef enum
+{
+    LED_STATE_OFF,
+    LED_STATE_ON,
+} led_state_e;
+
+void led_init(void);
+void led_set(led_e led, led_state_e state);
+#endif // LED_H

--- a/Src/main.c
+++ b/Src/main.c
@@ -1,27 +1,30 @@
 #include "./drivers/io.h"
 #include "./drivers/mcu_init.h"
+#include "./common/assert_handler.h"
+#include "./drivers/led.h"
+#include "./common/defines.h"
 static void test_setup(void)
 {
     mcu_init();
 }
+// static void test_assert(void)
+// {
+//     test_setup();
+//     ASSERT(0);
+// }
 static void blink_test_led()
 {
     test_setup();
-    // const struct io_config led_config = {
-    //     .mode = IO_MODE_OUPUT, .pupd = IO_NO_PUPD, .speed = IO_SPEED_LOW, .type = IO_TYPE_PP
-    // };
-    // io_configure(IO_TEST_LED, &led_config);
-
-    // volatile unsigned int i;
-    // io_out_e out = IO_OUT_LOW;
-
+    led_init();
+    // led_init();
+    volatile int j;
+    led_state_e led_state = LED_STATE_OFF;
     while (1) {
-        // out = (out == IO_OUT_LOW) ? IO_OUT_HIGH : IO_OUT_LOW;
-        io_set_output(IO_TEST_LED, IO_OUT_HIGH);
-        // for (i = 100000; i > 0; i--) { } // delay
+        led_state = (led_state == LED_STATE_OFF) ? LED_STATE_ON : LED_STATE_OFF;
+        led_set(LED_TEST, led_state);
+        BUSY_WAIT_ms(80)
     }
 }
-
 
 // static void test_nucleo_board_io_pins_output(void)
 // {
@@ -36,17 +39,15 @@ static void blink_test_led()
 //     while (1) {
 //         for (i = 0; i < sizeof(io_pins) / sizeof(io_pins[0]); i++) {
 //             io_set_output(io_pins[i], IO_OUT_HIGH);
-//             for (j = 10000; j > 0; j--) { }; // delay
+//             BUSY_WAIT_ms(80)
 //             io_set_output(io_pins[i], IO_OUT_LOW);
 //         }
 //     }
 // }
 // static void test_nucleo_board_io_pins_input(void)
 // {
-//     const struct io_config led_config = {
-//         .mode = IO_MODE_OUPUT, .pupd = IO_NO_PUPD, .speed = IO_SPEED_VERY_HIGH, .type =
-//         IO_TYPE_PP
-//     };
+//     test_setup();
+//     led_init();
 //     const struct io_config input_config = {
 //         .mode = IO_MODE_INPUT, .pupd = IO_PORT_PU, .speed = IO_SPEED_LOW, .type = IO_TYPE_PP
 //     };
@@ -65,7 +66,7 @@ static void blink_test_led()
 //                              IO_IR_REMOTE,         IO_TEST_LED };
 //     for (i = 0; i < sizeof(io_pins) / sizeof(io_pins[0]); i++) {
 //         if (io_pins[i] == IO_TEST_LED) { // pin for nucleo board onboard led
-//             io_configure(io_pins[i], &led_config);
+//             continue;
 //         } else {
 //             io_configure(io_pins[i], &input_config);
 //         }
@@ -75,23 +76,23 @@ static void blink_test_led()
 //         if (io_pins[i] == IO_TEST_LED) { // pin for nucleo board onboard led
 //             continue;
 //         }
-//         io_set_output(IO_TEST_LED, IO_OUT_HIGH);
+//         led_set(LED_TEST, LED_STATE_ON);
 //         // Wait for user to connect pull down to escape the loop
 //         while (io_get_input(io_pins[i]) == IO_IN_HIGH) {
-//             for (j = 10000; j > 0; j--) { }; // delay
+//             BUSY_WAIT_ms(80)
 //         }
-//         io_set_output(IO_TEST_LED, IO_OUT_LOW);
+//         led_set(LED_TEST, LED_STATE_OFF);
 //         // wait for user to disconnect pulldown for pin to go HIGH again and leave the loop
 //         while (io_get_input(io_pins[i]) == IO_IN_LOW) {
-//             for (j = 10000; j > 0; j--) { }; // delay
+//              BUSY_WAIT_ms(80)
 //         }
 //     }
 //     // led flashes after all input pins are tested in order
 //     while (1) {
-//         io_set_output(IO_TEST_LED, IO_OUT_HIGH);
-//         for (j = 10000; j > 0; j--) { }; // delay
-//         io_set_output(IO_TEST_LED, IO_OUT_LOW);
-//         for (j = 200000; j > 0; j--) { }; // delay
+//         led_set(LED_TEST, LED_STATE_ON);
+//         BUSY_WAIT_ms(80)
+//         led_set(LED_TEST, LED_STATE_OFF);
+//         BUSY_WAIT_ms(80)
 //     }
 // }
 int main(void)


### PR DESCRIPTION
failures and Led driver

ASSERT define created using an assert handler that triggers when a specific fault occurs, that is when  an assertion made is negated. The handler works by first creating a debug BREAKPOINT in the function body, then entering an endless loop, with TEST_LED blinking, until the controller is reset. The assert handler is employed in the led driver to ensure that TEST_LED has been configured properly, also to make sure the configuration check only occurs once.
The led driver is not used in the assert handler to prevent recursive assertions.