### PR TITLE
build(makefile): Tools for showing size of flash memory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,6 +126,7 @@ SZ = $(PREFIX)size
 endif
 # HEX = $(CP) -O ihex
 # BIN = $(CP) -O binary -S
+READELF=$(GCC_DIR)/$(PREFIX)readelf 
  
 #######################################
 # CFLAGS
@@ -219,7 +220,6 @@ $(OBJ_DIR)/%.o: %.S Makefile
 $(BIN_DIR)/$(TARGET).elf: $(OBJECTS) $(HEADERS) 
 	@mkdir -p $(dir $@)
 	$(CC) $(LDFLAGS) $^ -o $@
-	$(SZ) $@
 
 	
 #######################################
@@ -237,4 +237,10 @@ cppcheck:
 #######################################
 format:
 	@$(FORMAT) -i $(C_SOURCES) $(HEADERS)
+
+size: all
+	$(SZ) $(BIN_DIR)/$(TARGET).elf
+
+symbols: all
+	$(READELF) -s $(BIN_DIR)/$(TARGET).elf | sort -n -k3
 # *** EOF ***

--- a/Src/drivers/io.c
+++ b/Src/drivers/io.c
@@ -189,11 +189,11 @@ void io_init(void)
     io_configure(IO_UNUSED_28, &io_unused_config);
     io_configure(IO_UNUSED_29, &io_unused_config);
 }
-static inline uint8_t io_get_port(io_e io)
+static uint8_t io_get_port(io_e io)
 {
     return (io & IO_PORT_MASK) >> IO_PORT_OFFSET;
 }
-static inline uint8_t io_get_pin_idx(io_e io)
+static uint8_t io_get_pin_idx(io_e io)
 {
     return (io & IO_PIN_MASK);
 }


### PR DESCRIPTION
Add tools in makefile to show how much space of flash memory is taken by the codebase. Alos added a tool to read the elf file executable to see the space breakdown for the codebase.
Removed inline from the IO functions as it caused a reduction is space taken.