### PR TITLE
fix(clock): Increased clock speed to 80Mhz

### DIFF
--- a/Src/common/defines.h
+++ b/Src/common/defines.h
@@ -5,8 +5,10 @@
 #define ARRAY_SIZE(array) (sizeof(array) / sizeof(array[0]))
 
 // STM32L3 runs at default 4MHz
-#define CLOCK_FREQ_4MZ (4000000U)
-#define CLOCK_FREQ_PER_ms (CLOCK_FREQ_4MZ / 1000U)
+// switched to 80Mhz using HSI and PLL clocks
+#define CLOCK_FREQ_1MHZ (1000000U)
+#define CLOCK_FREQ_80MHZ (80U * CLOCK_FREQ_1MHZ)
+#define CLOCK_FREQ_PER_ms (CLOCK_FREQ_80MHZ / 1000U)
 #define BUSY_WAIT_ms(delay_ms)                                                                     \
     for (j = (delay_ms * CLOCK_FREQ_PER_ms); j > 0; j--) {                                         \
     }; // takes the count for how long you want to delay

--- a/Src/drivers/mcu_init.c
+++ b/Src/drivers/mcu_init.c
@@ -1,8 +1,43 @@
 #include "mcu_init.h"
 #include "io.h"
 #include "stm32l4xx.h"
+#include "assert_handler.h"
+static void init_clocks()
+{
+    // turn HSI clock on
+    RCC->CR |= (0x1 << 8);
+    while (!(RCC->CR & (0x1 << 10)))
+        ;
+    // turn PLL clock off
+    RCC->CR &= ~(0x1 << 24);
+    while ((RCC->CR & (0x1 << 25)))
+        ;
+    // setting HSI as PLL source
+    RCC->PLLCFGR = (RCC->PLLCFGR & ~0x3) | 0x2;
+    // configuring the PLL prescalers to acheive 80Mhz
+    RCC->PLLCFGR &= ~(0x7 << 4); // PLLM = 1
+    RCC->PLLCFGR = (RCC->PLLCFGR & ~(0x7F << 8)) | (0xA << 8); // PLLN =10
+    RCC->PLLCFGR &= ~(0x3 << 25); // PLLR=2
+    RCC->PLLCFGR |= (0x1 << 24); // PLLCLCK enabled=7
 
+    /* 4 wait states for flash (configure before switching on PLL)*/
+    FLASH->ACR = (FLASH->ACR & ~0x7) | 0x4;
+    /* configure the AHB abd APB clock prescalers (configure before switching on PLL)*/
+    RCC->CFGR &= ~((0xF << 4) | (0x3 << 8) | (0x3 << 11));
+
+    // turn PLL clock on
+    RCC->CR |= (0x1 << 24);
+    while (!(RCC->CR & (0x1 << 25)))
+        ;
+
+    // set sys clock as PLL
+    RCC->CFGR &= ~0x3;
+    RCC->CFGR = (RCC->CFGR & ~0x3) | 0x3;
+    while ((RCC->CFGR & (0x3 << 2)) >> 2 != 0x3)
+        ;
+}
 void mcu_init(void)
 {
+    init_clocks();
     io_init();
 }


### PR DESCRIPTION
Increased clock speed from the default 4Mhz to the max value on the microcontroller 80Mhz. To do this the PLL clock using the HSI clock as a source, was set as the system clock.
The clock initilization was added to the mcu init function. The BUSY_WAIT macro was also updated to reflect the 80Mhz clock speed.