### PR TITLE
feat(driver): UART driver and io fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,8 @@ C_SOURCES_WITH_HEADERS = \
 	Src/drivers/io.c \
 	Src/drivers/mcu_init.c \
 	Src/drivers/led.c \
+	Src/drivers/uart.c \
+	Src/common/ring_buffer.c \
 	Src/common/assert_handler.c \
 
 ifndef TEST

--- a/Src/common/assert_handler.h
+++ b/Src/common/assert_handler.h
@@ -6,6 +6,13 @@
             assert_handler();                                                                      \
         }                                                                                          \
     } while (0)
+#define ASSERT_INTERRUPT(expression)                                                               \
+    do {                                                                                           \
+        if (!(expression)) {                                                                       \
+            while (1)                                                                              \
+                ;                                                                                  \
+        }                                                                                          \
+    } while (0)
 
 void assert_handler(void);
 

--- a/Src/common/ring_buffer.c
+++ b/Src/common/ring_buffer.c
@@ -1,0 +1,40 @@
+#include "ring_buffer.h"
+
+void ring_buffer_put(struct ring_buffer *rb, uint8_t data)
+{
+    rb->buffer[rb->head] = data;
+    rb->head++;
+    // Didnt use modulu for space savings
+    if (rb->head == rb->size) {
+        rb->head = 0;
+    }
+}
+uint8_t ring_buffer_get(struct ring_buffer *rb)
+{
+    const uint8_t buffer_val = rb->buffer[rb->tail];
+    rb->tail++;
+    // Didnt use modulu for space savings
+
+    if (rb->tail == rb->size) {
+        rb->tail = 0;
+    }
+    return buffer_val;
+}
+uint8_t ring_buffer_peek(const struct ring_buffer *rb)
+{
+    return rb->buffer[rb->tail];
+}
+bool ring_buffer_full(const struct ring_buffer *rb)
+{
+    // the buffer gets full when head + 1 = tail
+    // becuase you dont want to overwrite elements that you haven't read yet
+    uint8_t idx_after_head = rb->head + 1;
+    if (idx_after_head == rb->size) {
+        idx_after_head = 0;
+    }
+    return idx_after_head == rb->tail;
+}
+bool ring_buffer_empty(const struct ring_buffer *rb)
+{
+    return rb->head == rb->tail;
+}

--- a/Src/common/ring_buffer.h
+++ b/Src/common/ring_buffer.h
@@ -1,0 +1,15 @@
+#ifndef RING_BUFFER_H
+#define RING_BUFFER_H
+#include <stdint.h>
+#include <stdbool.h>
+struct ring_buffer
+{
+    uint8_t *buffer;
+    uint8_t head, tail, size;
+};
+void ring_buffer_put(struct ring_buffer *rb, uint8_t data);
+uint8_t ring_buffer_get(struct ring_buffer *rb);
+uint8_t ring_buffer_peek(const struct ring_buffer *rb);
+bool ring_buffer_full(const struct ring_buffer *rb);
+bool ring_buffer_empty(const struct ring_buffer *rb);
+#endif // RING_BUFFER_H

--- a/Src/drivers/io.c
+++ b/Src/drivers/io.c
@@ -24,7 +24,8 @@ static_assert(sizeof(io_ports_e) == 1,
               "Unexpected enum size"
               "-fshort-enums missing?");
 #endif
-#define IO_PORT_CNT (3U)
+#define IO_PORT_CNT (8U)
+#define IO_PORT_CNT_ISR (3U)
 #define IO_PIN_PER_PORT_CNT (16U)
 #define IO_PIN_CNT (48U)
 #define IO_EXTI_INTERRUPT_LINES_CNT (7U)
@@ -33,7 +34,7 @@ static_assert(sizeof(io_ports_e) == 1,
  * Configure the pin to prevent unpredictable noise for floating pins   */
 #define UNUSED_PIN_CONFIG                                                                          \
     {                                                                                              \
-        IO_MODE_INPUT, IO_PORT_PD, IO_SPEED_LOW, IO_TYPE_PP                                        \
+        IO_MODE_INPUT, IO_PORT_PD, IO_SPEED_LOW, IO_TYPE_PP, IO_AF_NONE                            \
     }
 
 static const struct io_config io_pins_initial_configs[IO_PIN_CNT] = {
@@ -41,58 +42,62 @@ static const struct io_config io_pins_initial_configs[IO_PIN_CNT] = {
     [IO_LD_FRONT_LEFT] = { .mode = IO_MODE_ANALOG,
                            .pupd = IO_NO_PUPD,
                            .speed = IO_SPEED_LOW,
-                           .type = IO_TYPE_PP },
+                           .type = IO_TYPE_PP,
+                           .af = IO_AF_NONE },
     [IO_LD_BACK_LEFT] = { .mode = IO_MODE_ANALOG,
                           .pupd = IO_NO_PUPD,
                           .speed = IO_SPEED_LOW,
-                          .type = IO_TYPE_PP },
+                          .type = IO_TYPE_PP,
+                          .af = IO_AF_NONE },
     [IO_LD_FRONT_RIGHT] = { .mode = IO_MODE_ANALOG,
                             .pupd = IO_NO_PUPD,
                             .speed = IO_SPEED_LOW,
-                            .type = IO_TYPE_PP },
+                            .type = IO_TYPE_PP,
+                            .af = IO_AF_NONE },
     [IO_LD_BACK_RIGHT] = { .mode = IO_MODE_ANALOG,
                            .pupd = IO_NO_PUPD,
                            .speed = IO_SPEED_LOW,
-                           .type = IO_TYPE_PP },
-    [IO_UNUSED_1] = UNUSED_PIN_CONFIG,
-    [IO_UNUSED_2] = UNUSED_PIN_CONFIG,
+                           .type = IO_TYPE_PP,
+                           .af = IO_AF_NONE },
     // test led setup as an output, held low initiailly
     [IO_TEST_LED] = { .mode = IO_MODE_OUPUT,
                       .pupd = IO_NO_PUPD,
                       .speed = IO_SPEED_VERY_HIGH,
-                      .type = IO_TYPE_PP },
+                      .type = IO_TYPE_PP,
+                      .af = IO_AF_NONE },
     /* Range sensor xshut set up as outputs*/
     [IO_XSHUT_FRONT_LEFT] = { .mode = IO_MODE_OUPUT,
                               .pupd = IO_NO_PUPD,
                               .speed = IO_SPEED_VERY_HIGH,
-                              .type = IO_TYPE_PP },
+                              .type = IO_TYPE_PP,
+                              .af = IO_AF_NONE },
     [IO_XSHUT_FRONT_RIGHT] = { .mode = IO_MODE_OUPUT,
                                .pupd = IO_NO_PUPD,
                                .speed = IO_SPEED_VERY_HIGH,
-                               .type = IO_TYPE_PP },
+                               .type = IO_TYPE_PP,
+                               .af = IO_AF_NONE },
     [IO_XSHUT_RIGHT] = { .mode = IO_MODE_OUPUT,
                          .pupd = IO_NO_PUPD,
                          .speed = IO_SPEED_VERY_HIGH,
-                         .type = IO_TYPE_PP },
+                         .type = IO_TYPE_PP,
+                         .af = IO_AF_NONE },
     [IO_XSHUT_LEFT] = { .mode = IO_MODE_OUPUT,
                         .pupd = IO_NO_PUPD,
                         .speed = IO_SPEED_VERY_HIGH,
-                        .type = IO_TYPE_PP },
+                        .type = IO_TYPE_PP,
+                        .af = IO_AF_NONE },
     [IO_XSHUT_FRONT] = { .mode = IO_MODE_OUPUT,
                          .pupd = IO_NO_PUPD,
                          .speed = IO_SPEED_VERY_HIGH,
-                         .type = IO_TYPE_PP },
+                         .type = IO_TYPE_PP,
+                         .af = IO_AF_NONE },
     // IR reciever setup as an input
     [IO_IR_REMOTE] = { .mode = IO_MODE_INPUT,
                        .pupd = IO_NO_PUPD,
                        .speed = IO_SPEED_LOW,
-                       .type = IO_TYPE_PP },
-    [IO_UNUSED_3] = UNUSED_PIN_CONFIG,
-    [IO_UNUSED_4] = UNUSED_PIN_CONFIG,
-    [IO_UNUSED_5] = UNUSED_PIN_CONFIG,
-    [IO_UNUSED_6] = UNUSED_PIN_CONFIG,
-    [IO_UNUSED_7] = UNUSED_PIN_CONFIG,
-    [IO_UNUSED_8] = UNUSED_PIN_CONFIG,
+                       .type = IO_TYPE_PP,
+                       .af = IO_AF_NONE },
+
     /* Range sensor interrupt output open drain
      * A 10k ohm external pull up resistor is suggested but the microcontrollers internal pull up
      is
@@ -100,48 +105,46 @@ static const struct io_config io_pins_initial_configs[IO_PIN_CNT] = {
     [IO_RANGE_SENSOR_INT_FRONT] = { .mode = IO_MODE_INPUT,
                                     .pupd = IO_PORT_PU,
                                     .speed = IO_SPEED_LOW,
-                                    .type = IO_TYPE_PP },
-    [IO_UNUSED_9] = UNUSED_PIN_CONFIG,
-    [IO_UNUSED_10] = UNUSED_PIN_CONFIG,
-    [IO_UNUSED_11] = UNUSED_PIN_CONFIG,
-    [IO_UNUSED_12] = UNUSED_PIN_CONFIG,
-
+                                    .type = IO_TYPE_PP,
+                                    .af = IO_AF_NONE },
     /* uart transmit
      * mode: alternate function
      * pupd: no pupd (output not required)*/
     [IO_UART_TX] = { .mode = IO_MODE_ALTFN,
                      .pupd = IO_NO_PUPD,
                      .speed = IO_SPEED_HIGH,
-                     .type = IO_TYPE_PP },
+                     .type = IO_TYPE_PP,
+                     .af = IO_AF_7 },
     /* uart recieve
      * mode: alternate function
      * pupd: pulled down*/
     [IO_UART_RX] = { .mode = IO_MODE_ALTFN,
                      .pupd = IO_PORT_PD,
                      .speed = IO_SPEED_LOW,
-                     .type = IO_TYPE_PP },
-    [IO_UNUSED_13] = UNUSED_PIN_CONFIG,
-    [IO_UNUSED_14] = UNUSED_PIN_CONFIG,
+                     .type = IO_TYPE_PP,
+                     .af = IO_AF_7 },
 
     // motor channel pins setup as output +
     [IO_MOTOR_LEFT_CH1] = { .mode = IO_MODE_OUPUT,
                             .pupd = IO_NO_PUPD,
                             .speed = IO_SPEED_VERY_HIGH,
-                            .type = IO_TYPE_PP },
+                            .type = IO_TYPE_PP,
+                            .af = IO_AF_NONE },
     [IO_MOTOR_LEFT_CH2] = { .mode = IO_MODE_OUPUT,
                             .pupd = IO_NO_PUPD,
                             .speed = IO_SPEED_VERY_HIGH,
-                            .type = IO_TYPE_PP },
+                            .type = IO_TYPE_PP,
+                            .af = IO_AF_NONE },
     [IO_MOTOR_RIGHT_CH1] = { .mode = IO_MODE_OUPUT,
                              .pupd = IO_NO_PUPD,
                              .speed = IO_SPEED_VERY_HIGH,
-                             .type = IO_TYPE_PP },
+                             .type = IO_TYPE_PP,
+                             .af = IO_AF_NONE },
     [IO_MOTOR_RIGHT_CH2] = { .mode = IO_MODE_OUPUT,
                              .pupd = IO_NO_PUPD,
                              .speed = IO_SPEED_VERY_HIGH,
-                             .type = IO_TYPE_PP },
-    [IO_UNUSED_15] = UNUSED_PIN_CONFIG,
-    [IO_UNUSED_16] = UNUSED_PIN_CONFIG,
+                             .type = IO_TYPE_PP,
+                             .af = IO_AF_NONE },
 
     /* I2C pins
      * mode = alternate function
@@ -150,22 +153,43 @@ static const struct io_config io_pins_initial_configs[IO_PIN_CNT] = {
     [IO_I2C_SCL] = { .mode = IO_MODE_ALTFN,
                      .pupd = IO_NO_PUPD,
                      .speed = IO_SPEED_VERY_HIGH,
-                     .type = IO_TYPE_OD },
+                     .type = IO_TYPE_OD,
+                     .af = IO_AF_4 },
     [IO_I2C_SDA] = { .mode = IO_MODE_ALTFN,
                      .pupd = IO_NO_PUPD,
                      .speed = IO_SPEED_VERY_HIGH,
-                     .type = IO_TYPE_OD },
-    [IO_UNUSED_17] = UNUSED_PIN_CONFIG,
-    [IO_UNUSED_18] = UNUSED_PIN_CONFIG,
+                     .type = IO_TYPE_OD,
+                     .af = IO_AF_4 },
+
     // motor pwm pins set up as alternate function
     [IO_MOTOR_PWM_LEFT] = { .mode = IO_MODE_ALTFN,
                             .pupd = IO_NO_PUPD,
                             .speed = IO_SPEED_VERY_HIGH,
-                            .type = IO_TYPE_PP },
+                            .type = IO_TYPE_PP,
+                            .af = IO_AF_NONE },
     [IO_MOTOR_PWM_RIGHT] = { .mode = IO_MODE_ALTFN,
                              .pupd = IO_NO_PUPD,
                              .speed = IO_SPEED_VERY_HIGH,
-                             .type = IO_TYPE_PP },
+                             .type = IO_TYPE_PP,
+                             .af = IO_AF_NONE },
+    [IO_UNUSED_1] = UNUSED_PIN_CONFIG,
+    [IO_UNUSED_2] = UNUSED_PIN_CONFIG,
+    [IO_UNUSED_3] = UNUSED_PIN_CONFIG,
+    [IO_UNUSED_4] = UNUSED_PIN_CONFIG,
+    [IO_UNUSED_5] = UNUSED_PIN_CONFIG,
+    [IO_UNUSED_6] = UNUSED_PIN_CONFIG,
+    [IO_UNUSED_7] = UNUSED_PIN_CONFIG,
+    [IO_UNUSED_8] = UNUSED_PIN_CONFIG,
+    [IO_UNUSED_9] = UNUSED_PIN_CONFIG,
+    [IO_UNUSED_10] = UNUSED_PIN_CONFIG,
+    [IO_UNUSED_11] = UNUSED_PIN_CONFIG,
+    [IO_UNUSED_12] = UNUSED_PIN_CONFIG,
+    [IO_UNUSED_13] = UNUSED_PIN_CONFIG,
+    [IO_UNUSED_14] = UNUSED_PIN_CONFIG,
+    [IO_UNUSED_15] = UNUSED_PIN_CONFIG,
+    [IO_UNUSED_16] = UNUSED_PIN_CONFIG,
+    [IO_UNUSED_17] = UNUSED_PIN_CONFIG,
+    [IO_UNUSED_18] = UNUSED_PIN_CONFIG,
     [IO_UNUSED_19] = UNUSED_PIN_CONFIG,
     [IO_UNUSED_20] = UNUSED_PIN_CONFIG,
     [IO_UNUSED_21] = UNUSED_PIN_CONFIG,
@@ -179,10 +203,11 @@ static const struct io_config io_pins_initial_configs[IO_PIN_CNT] = {
 void io_init(void)
 {
     io_e io_pin;
-    const struct io_config io_unused_config = UNUSED_PIN_CONFIG;
+    const struct io_config io_unused_config = { IO_MODE_INPUT, IO_PORT_PD, IO_SPEED_LOW, IO_TYPE_PP,
+                                                IO_AF_NONE };
 
     for (io_pin = (io_e)IO_PA_0; io_pin < ARRAY_SIZE(io_pins_initial_configs); io_pin++) {
-        if (io_pin == IO_UNUSED_6 || io_pin == IO_UNUSED_7) {
+        if (io_pin == IO_UNUSED_4 || io_pin == IO_UNUSED_5) {
             continue;
         }
         io_configure(io_pin, &io_pins_initial_configs[io_pin]);
@@ -209,9 +234,10 @@ typedef enum
 /*- Array of GPIO ports, the ports are defined as struct pointers in the header files
   - Used an array of the ports to allow for cleaner code and no switch statments
   - Added only 3 ports since only A,B and C are being used in the sumo bot*/
-static GPIO_TypeDef *const gpio_port_regs[IO_PORT_CNT] = { GPIOA, GPIOB, GPIOC };
+static GPIO_TypeDef *const gpio_port_regs[IO_PORT_CNT] = { GPIOA, GPIOB, GPIOC, GPIOD,
+                                                           GPIOE, GPIOF, GPIOG, GPIOH };
 
-static isr_function isr_functions[IO_PORT_CNT][IO_PIN_PER_PORT_CNT] = {
+static isr_function isr_functions[IO_PORT_CNT_ISR][IO_PIN_PER_PORT_CNT] = {
     [PORTA] = { NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
                 NULL, NULL },
     [PORTB] = { NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
@@ -241,6 +267,7 @@ void io_configure(io_e io, const struct io_config *config)
 
     case IO_MODE_ALTFN:
         io_set_output_speed(io, config->speed);
+        io_set_AF(io, config->af);
         break;
 
     case IO_MODE_ANALOG:
@@ -324,6 +351,15 @@ io_in_e io_get_input(io_e io)
     const GPIO_TypeDef *GPIO = gpio_port_regs[port];
     const uint8_t input = GPIO->IDR & (0x1 << pin);
     return input ? IO_IN_HIGH : IO_IN_LOW;
+}
+void io_set_AF(io_e io, io_af_e af)
+{
+    const uint8_t pin = io_get_pin_idx(io);
+    const uint8_t port = io_get_port(io);
+    GPIO_TypeDef *GPIO = gpio_port_regs[port];
+    uint8_t af_section = pin / 8;
+    GPIO->AFR[af_section] &= ~(0xF << (pin * 4));
+    GPIO->AFR[af_section] |= (af << (pin * 4));
 }
 void io_get_io_config(io_e io, struct io_config *current_config)
 {

--- a/Src/drivers/io.h
+++ b/Src/drivers/io.h
@@ -61,29 +61,31 @@ typedef enum
     // PA
     IO_LD_FRONT_LEFT = IO_PA_0,
     IO_LD_BACK_LEFT = IO_PA_1,
-    IO_UNUSED_1 = IO_PA_2,
-    IO_UNUSED_2 = IO_PA_3,
+    // IO_UNUSED_1 = IO_PA_2,
+    // IO_UNUSED_2 = IO_PA_3,
+    IO_UART_TX = IO_PA_2,
+    IO_UART_RX = IO_PA_3,
     IO_LD_FRONT_RIGHT = IO_PA_4,
     IO_TEST_LED = IO_PA_5,
     IO_XSHUT_FRONT_LEFT = IO_PA_6,
     IO_XSHUT_RIGHT = IO_PA_7,
     IO_IR_REMOTE = IO_PA_8,
     IO_XSHUT_LEFT = IO_PA_9,
-    IO_UNUSED_3 = IO_PA_10,
-    IO_UNUSED_4 = IO_PA_11,
-    IO_UNUSED_5 = IO_PA_12,
-    IO_UNUSED_6 = IO_PA_13,
-    IO_UNUSED_7 = IO_PA_14,
-    IO_UNUSED_8 = IO_PA_15,
+    IO_UNUSED_1 = IO_PA_10,
+    IO_UNUSED_2 = IO_PA_11,
+    IO_UNUSED_3 = IO_PA_12,
+    IO_UNUSED_4 = IO_PA_13,
+    IO_UNUSED_5 = IO_PA_14,
+    IO_UNUSED_6 = IO_PA_15,
     // PB
     IO_LD_BACK_RIGHT = IO_PB_0,
     IO_RANGE_SENSOR_INT_FRONT = IO_PB_1,
-    IO_UNUSED_9 = IO_PB_2,
-    IO_UNUSED_10 = IO_PB_3,
-    IO_UNUSED_11 = IO_PB_4,
-    IO_UNUSED_12 = IO_PB_5,
-    IO_UART_TX = IO_PB_6,
-    IO_UART_RX = IO_PB_7,
+    IO_UNUSED_7 = IO_PB_2,
+    IO_UNUSED_8 = IO_PB_3,
+    IO_UNUSED_9 = IO_PB_4,
+    IO_UNUSED_10 = IO_PB_5,
+    IO_UNUSED_11 = IO_PB_6,
+    IO_UNUSED_12 = IO_PB_7,
     IO_UNUSED_13 = IO_PB_8,
     IO_UNUSED_14 = IO_PB_9,
     IO_MOTOR_LEFT_CH1 = IO_PB_10,
@@ -155,7 +157,26 @@ typedef enum
     IO_TYPE_PP, // push pull
     IO_TYPE_OD // open drain
 } io_out_type_e;
-
+typedef enum
+{
+    IO_AF_0,
+    IO_AF_1,
+    IO_AF_2,
+    IO_AF_3,
+    IO_AF_4,
+    IO_AF_5,
+    IO_AF_6,
+    IO_AF_7,
+    IO_AF_8,
+    IO_AF_9,
+    IO_AF_10,
+    IO_AF_11,
+    IO_AF_12,
+    IO_AF_13,
+    IO_AF_14,
+    IO_AF_15,
+    IO_AF_NONE
+} io_af_e;
 typedef enum
 {
     IO_FALLING_TRIGGER,
@@ -187,6 +208,7 @@ struct io_config
     io_pupd_e pupd;
     io_ouput_speed_e speed;
     io_out_type_e type;
+    io_af_e af;
 };
 
 // FUNCTIONS
@@ -199,6 +221,7 @@ void io_set_mode(io_e io, io_mode_e mode);
 void io_set_output_type(io_e io, io_out_type_e type);
 void io_set_pupd(io_e io, io_pupd_e pupd);
 void io_set_output_speed(io_e io, io_ouput_speed_e speed);
+void io_set_AF(io_e io, io_af_e af);
 void io_set_output(io_e io, io_out_e out);
 io_in_e io_get_input(io_e io);
 

--- a/Src/drivers/led.c
+++ b/Src/drivers/led.c
@@ -4,9 +4,11 @@
 #include "io.h"
 #include "stdbool.h"
 static bool initialized = false;
-static const struct io_config led_config = {
-    .mode = IO_MODE_OUPUT, .pupd = IO_NO_PUPD, .speed = IO_SPEED_VERY_HIGH, .type = IO_TYPE_PP
-};
+static const struct io_config led_config = { .mode = IO_MODE_OUPUT,
+                                             .pupd = IO_NO_PUPD,
+                                             .speed = IO_SPEED_VERY_HIGH,
+                                             .type = IO_TYPE_PP,
+                                             .af = IO_AF_NONE };
 void led_init(void)
 {
     /* First assert that led_init has not been called yet

--- a/Src/drivers/uart.c
+++ b/Src/drivers/uart.c
@@ -1,0 +1,133 @@
+#include "uart.h"
+#include "io.h"
+#include "defines.h"
+#include "ring_buffer.h"
+#include "assert_handler.h"
+#include "stm32l4xx.h"
+#include "stdbool.h"
+#include <assert.h>
+#include <string.h>
+#define UART_RING_BUFFER_SIZE (16)
+static uint8_t buffer[UART_RING_BUFFER_SIZE];
+static struct ring_buffer tx_buffer = {
+    .buffer = buffer, .head = 0, .tail = 0, .size = (sizeof(buffer) / sizeof(buffer[0]))
+};
+/* Caluculate the USARTDIV which is used to configure the baudrate for the USART peripheral
+ * USARTDIV = SystemCoreClock / baudrate
+ * The USART peripheral here is configured to run in normal mode (16 smapling, 8 smapling is
+diasabled)*/
+#define BAUDRATE (115200U)
+#define SYSCLK (80000000U)
+#define FCK (SYSCLK)
+#define USARTDIV (FCK / BAUDRATE)
+
+static_assert(sizeof(USARTDIV) < 0xFFFFu, "USARTDIV must fit into 16-bits");
+static_assert(USARTDIV >= 16U, "USARTDIV for the BAUDRATE must be atleast 16 decimal");
+
+static bool initialized = false;
+static void init_uart_clock(void)
+{
+    // set clock for USART2 in APB1
+    RCC->APB1ENR1 |= (0x1 << 17);
+}
+static inline void uart_tx_enable_interrupt(void)
+{
+    // TXEIE (transmit interrupt enable)
+    USART2->CR1 |= 0x1 << 7;
+}
+
+void uart_init(void)
+{
+    ASSERT(!initialized);
+    init_uart_clock();
+    USART2->CR1 &= ~((0x1 << 12) | (0x1 << 28)); // set the word length as 8 bits
+
+    USART2->BRR = USARTDIV; // set the baudrate as 1152000
+    USART2->CR2 &= ~(0x3 << 12); // set number of stop bits as 1
+
+    /* set TE (transmit enable), RE (recive enable) bits first
+     set the UE (USART enable) bit after all configurations have been done*/
+    USART2->CR1 |= ((0x1 << 3) | (0x1 << 2) | 0x1);
+    __disable_irq();
+    NVIC_EnableIRQ(USART2_IRQn);
+    __enable_irq();
+    initialized = true;
+}
+static void uart_tx_start(void)
+{
+    if (!ring_buffer_empty(&tx_buffer)) {
+        uart_tx_enable_interrupt();
+    }
+}
+
+void USART2_IRQHandler(void)
+{ /* check for if TXE and TXEIE are ready (both 1)
+   * always check the flage and its interrupt to ensure the interrupt cleanly ends
+   * without TXEIE checked, even if TXEIE is disabled another interrupt could trigger the ISR
+   * since TXE is 1 after TDR is emptied the if guard is awlays true during so the ISR hangs in the
+   * 2nd if guard
+   * so checking the diabled TXEIE prevents the ISR from happening even if it is called */
+    if (USART2->ISR & (0x1 << 7) && (USART2->CR1 & (0x1 << 7))) {
+
+        ASSERT_INTERRUPT(!ring_buffer_empty(&tx_buffer));
+        // Add character to TDR
+        USART2->TDR = ring_buffer_peek(&tx_buffer);
+
+        // remove the transmitted data from the TX buffer
+        ring_buffer_get(&tx_buffer);
+
+        // clear the TXEIE interrupt
+        USART2->CR1 &= ~(0x1 << 7);
+
+        // send all the data in the ring buffer if it is filled faster than it is read
+        if (!ring_buffer_empty(&tx_buffer)) {
+            uart_tx_start();
+        }
+    }
+
+    /* check for if TC and TCIE are ready*/
+    if (USART2->ISR & (0x1 << 6) && (USART2->CR1 & (0x1 << 6))) {
+        // clear the TCIE interrupt
+        USART2->CR1 &= ~(0x1 << 6);
+    }
+}
+void uart_putchar_interrupt(char c)
+{
+    // wait till ring buffer empties if full
+    while (ring_buffer_full(&tx_buffer))
+        ;
+    NVIC_DisableIRQ(USART2_IRQn);
+    bool tx_ongoing = !ring_buffer_empty(&tx_buffer);
+    ring_buffer_put(&tx_buffer, c);
+    if (!tx_ongoing) {
+        uart_tx_start();
+    }
+    NVIC_EnableIRQ(USART2_IRQn);
+    if (c == '\n') {
+        uart_putchar_interrupt('\r');
+    }
+}
+void uart_print_interrupt(const char *string)
+{
+    size_t i = 0;
+    for (i = 0; i < strlen(string); i++) {
+        uart_putchar_interrupt(string[i]);
+    }
+}
+
+void uart_putchar_polling(char c)
+{
+    ASSERT(initialized);
+    /* wait for TXE to be empty
+    TXE is the transmit data empty register
+    it is set when data is transfered to the shft register */
+    while (!(USART2->ISR & (0x1 << 7)))
+        ;
+
+    /* some terminals need to see the carriage-return \r character after the line feed \n to
+     start a new line */
+    USART2->TDR = c;
+    if (c == '\n') {
+        uart_putchar_polling('\r');
+    }
+}

--- a/Src/drivers/uart.h
+++ b/Src/drivers/uart.h
@@ -1,0 +1,8 @@
+#ifndef UART_H
+#define UART_H
+/*Uart driver to print messages to the terminal to aid in debugging*/
+void uart_init(void);
+void uart_putchar_polling(char c);
+void uart_putchar_interrupt(char c);
+void uart_print_interrupt(const char *string);
+#endif // UART_H

--- a/Src/main.c
+++ b/Src/main.c
@@ -1,5 +1,6 @@
 
 #include "./common/assert_handler.h"
+#include "defines.h"
 int main(void)
 {
     ASSERT(0);

--- a/Src/test/test.c
+++ b/Src/test/test.c
@@ -3,6 +3,7 @@
 #include "../common/assert_handler.h"
 #include "../drivers/led.h"
 #include "../common/defines.h"
+#include "../drivers/uart.h"
 static const io_e io_pins[] = { IO_I2C_SDA,           IO_I2C_SCL,
                                 IO_LD_FRONT_LEFT,     IO_LD_BACK_LEFT,
                                 IO_UART_TX,           IO_UART_RX,
@@ -39,13 +40,26 @@ static void test_blink_led(void)
     }
 }
 SUPPRESS_UNUSED
+static void test_uart_interrupt(void)
+{
+    test_setup();
+    uart_init();
+    volatile int j;
+    while (1) {
+        uart_print_interrupt("hello boy\n");
+        BUSY_WAIT_ms(60);
+    }
+}
+SUPPRESS_UNUSED
 static void test_nucleo_board_io_pins_output(void)
 {
     test_setup();
 
-    const struct io_config output_config = {
-        .mode = IO_MODE_OUPUT, .pupd = IO_NO_PUPD, .speed = IO_SPEED_VERY_HIGH, .type = IO_TYPE_PP
-    };
+    const struct io_config output_config = { .mode = IO_MODE_OUPUT,
+                                             .pupd = IO_NO_PUPD,
+                                             .speed = IO_SPEED_VERY_HIGH,
+                                             .type = IO_TYPE_PP,
+                                             .af = IO_AF_NONE };
     volatile unsigned int i;
     volatile unsigned int j;
     for (i = 0; i < sizeof(io_pins) / sizeof(io_pins[0]); i++) {
@@ -64,9 +78,11 @@ static void test_nucleo_board_io_pins_input(void)
     test_setup();
     led_init();
 
-    const struct io_config input_config = {
-        .mode = IO_MODE_INPUT, .pupd = IO_PORT_PU, .speed = IO_SPEED_LOW, .type = IO_TYPE_PP
-    };
+    const struct io_config input_config = { .mode = IO_MODE_INPUT,
+                                            .pupd = IO_PORT_PU,
+                                            .speed = IO_SPEED_LOW,
+                                            .type = IO_TYPE_PP,
+                                            .af = IO_AF_NONE };
     volatile unsigned int i;
     volatile unsigned int j;
 
@@ -119,9 +135,11 @@ SUPPRESS_UNUSED
 static void test_io_interrupt(void)
 {
     test_setup();
-    const struct io_config input_config = {
-        .mode = IO_MODE_INPUT, .pupd = IO_PORT_PU, .speed = IO_SPEED_LOW, .type = IO_TYPE_PP
-    };
+    const struct io_config input_config = { .mode = IO_MODE_INPUT,
+                                            .pupd = IO_PORT_PU,
+                                            .speed = IO_SPEED_LOW,
+                                            .type = IO_TYPE_PP,
+                                            .af = IO_AF_NONE };
     io_configure((io_e)IO_PA_8, &input_config);
     io_configure((io_e)IO_PB_3, &input_config);
     led_init();


### PR DESCRIPTION
Created a UART driver using a ring buffer to store string to be transmitted. The ring buffer makes use of put and get functions to update the buffer with checks for buffer fullness or emptiness before adding or removing data. Interrupt handling for the UART trnamission was employed, as polling is much more cpu exhaustive.
A simple temporary print function was used to test the UART driver. A new assert macro was added for interrupts to be filled out later. IO pins for UART TX and RX were updated and Alternate Function intitialization for the IO pins was added to the io_init function.