### PR TITLE
feat(trace): TRACE macro to call the printf external implementation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,8 @@ jobs:
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v3
+        with:
+          submodules: "true"
       - run: make format
       - run: make cppcheck
       - run: GCC_PATH=/home/stm32/dev/tools/gcc-arm-none-eabi-10.3-2021.10/bin make

--- a/Makefile
+++ b/Makefile
@@ -137,7 +137,7 @@ endif
 # HEX = $(CP) -O ihex
 # BIN = $(CP) -O binary -S
 READELF=$(GCC_DIR)/$(PREFIX)readelf 
- 
+ADDR2LINE=$(GCC_DIR)/$(PREFIX)addr2line 
 #######################################
 # CFLAGS
 #######################################
@@ -178,9 +178,9 @@ C_INCLUDES =  \
 
 
 # compile gcc flags
-ASFLAGS = $(MCU) $(AS_DEFS) $(AS_INCLUDES) $(DEFINES) $(OPT) -Wall -fdata-sections -ffunction-sections
+ASFLAGS = $(MCU) $(AS_DEFS) $(AS_INCLUDES) $(DEFINES) $(OPT) -g -Wall -fdata-sections -ffunction-sections
 
-CFLAGS += $(MCU) $(C_DEFS) $(addprefix -I,$(C_INCLUDES)) $(OPT) $(DEFINES) -fshort-enums -Wall -Wextra -Werror -fdata-sections -ffunction-sections
+CFLAGS += $(MCU) $(C_DEFS) $(addprefix -I,$(C_INCLUDES)) $(OPT) $(DEFINES)  -g -gdwarf-2 -fshort-enums -Wall -Wextra -Werror -fdata-sections -ffunction-sections
 
 ifeq ($(DEBUG), 1)
 CFLAGS += -g -gdwarf-2
@@ -196,7 +196,7 @@ LDSCRIPT = STM32L476RGTX_FLASH.ld
 # libraries
 LIBS = -lc -lm -lnosys 
 LIBDIR = 
-LDFLAGS = $(MCU) -specs=nano.specs -T$(LDSCRIPT) $(LIBDIR) $(LIBS) -Wl,--gc-sections
+LDFLAGS += $(MCU) -specs=nano.specs -T$(LDSCRIPT) $(LIBDIR) $(LIBS)  -g -Wl,--gc-sections
 
 # default action: build all
 all: $(BIN_DIR)/$(TARGET).elf 
@@ -253,4 +253,7 @@ size: all
 
 symbols: all
 	$(READELF) -s $(BIN_DIR)/$(TARGET).elf | sort -n -k3
+
+addr2line: all
+	$(ADDR2LINE) -e $(BIN_DIR)/$(TARGET).elf $(ADDR)
 # *** EOF ***

--- a/Src/common/assert_handler.c
+++ b/Src/common/assert_handler.c
@@ -1,15 +1,35 @@
 #include "assert_handler.h"
 #include "defines.h"
+#include "uart.h"
 #include "stm32l4xx.h"
-
+#include "../../external/printf/printf.h"
 #define BREAKPOINT __asm volatile("bkpt #0");
 
-void assert_handler(void)
-{
-    BREAKPOINT
+// Text + Program counter + Mull termination \0
+#define ASSERT_STRING_MAX_SIZE (15u + 6u + 1u)
 
+static void assert_trace(void *program_counter)
+{
+    // configure UART TX pin
+    RCC->AHB2ENR |= 0x1 << 2;
+    GPIOC->MODER &= ~(0x3 << (2 * 10));
+    GPIOC->MODER |= (0x2 << (2 * 10));
+    GPIOC->OTYPER &= ~(0x1 << 10);
+    GPIOC->OSPEEDR &= ~(0x2 << (2 * 10));
+    GPIOC->OSPEEDR |= (0x2 << (2 * 10));
+    GPIOC->AFR[1] &= ~(0xF << ((10 - 8) * 4));
+    GPIOC->AFR[1] |= (0x7 << ((10 - 8) * 4));
+    uart_init_assert();
+
+    char assert_string[ASSERT_STRING_MAX_SIZE];
+    // writes to assert_string buffer the fomratted string
+    snprintf(assert_string, sizeof(assert_string), "ASSERT 0x%x\n", program_counter);
+    uart_trace_assert(assert_string);
+}
+static void assert_blink_led(void)
+{
     /* Accessing registers directly to config TEST LED to prevent
-    calling functions that have assertions, this prevents recursive assertions*/
+       calling functions that have assertions, this prevents recursive assertions*/
     RCC->AHB2ENR |= 0x1;
 
     GPIOA->MODER &= ~(0x3 << (2 * 5));
@@ -21,6 +41,12 @@ void assert_handler(void)
     volatile int j;
     while (1) {
         GPIOA->ODR ^= (0x1 << 5);
-        BUSY_WAIT_ms(120)
+        BUSY_WAIT_ms(90)
     };
+}
+void assert_handler(void *program_counter)
+{
+    BREAKPOINT
+    assert_trace(program_counter);
+    assert_blink_led();
 }

--- a/Src/common/assert_handler.h
+++ b/Src/common/assert_handler.h
@@ -1,9 +1,12 @@
 #ifndef ASSERT_HANDLER_H
+#include <stdint.h>
 /* Assert on microcontroller to turn off motors during a fault*/
 #define ASSERT(expression)                                                                         \
     do {                                                                                           \
         if (!(expression)) {                                                                       \
-            assert_handler();                                                                      \
+            void *pc;                                                                              \
+            asm("mov %0, pc" : "=r"(pc));                                                          \
+            assert_handler(pc);                                                                    \
         }                                                                                          \
     } while (0)
 #define ASSERT_INTERRUPT(expression)                                                               \
@@ -14,6 +17,6 @@
         }                                                                                          \
     } while (0)
 
-void assert_handler(void);
+void assert_handler(void *program_counter);
 
 #endif // ASSERT_HANDLER_H

--- a/Src/common/trace.c
+++ b/Src/common/trace.c
@@ -1,0 +1,23 @@
+#include "trace.h"
+#include "uart.h"
+#include "assert_handler.h"
+#include "../../external/printf/printf.h"
+#include <stdbool.h>
+#include <stdarg.h>
+
+static bool initialized = false;
+
+void trace_init(void)
+{
+    ASSERT(!initialized);
+    uart_init();
+    initialized = true;
+}
+void trace(const char *format, ...)
+{
+    ASSERT(initialized);
+    va_list args;
+    va_start(args, format);
+    vprintf(format, args);
+    va_end(args);
+}

--- a/Src/common/trace.h
+++ b/Src/common/trace.h
@@ -1,0 +1,13 @@
+#ifndef TRACE_H
+#define TRACE_H
+#define TRACE(fmt, ...) trace("%s:%d: " fmt "\n", __FILE__, __LINE__, ##__VA_ARGS__)
+
+#ifndef DISABLE_TRACE
+void trace_init(void);
+void trace(const char *format, ...);
+#else
+#define trace_init() ;
+#define trace(fmt, ...) ;
+#endif
+
+#endif // TRACE_H

--- a/Src/drivers/uart.c
+++ b/Src/drivers/uart.c
@@ -93,7 +93,9 @@ void USART3_IRQHandler(void)
         USART3->CR1 &= ~(0x1 << 6);
     }
 }
-void uart_putchar_interrupt(char c)
+//_putchar is the function name required by the printf implementation
+// renamed the uart driver interrupt function to _putchar
+void _putchar(char c)
 {
     // wait till ring buffer empties if full
     while (ring_buffer_full(&tx_buffer))
@@ -106,14 +108,7 @@ void uart_putchar_interrupt(char c)
     }
     NVIC_EnableIRQ(USART3_IRQn);
     if (c == '\n') {
-        uart_putchar_interrupt('\r');
-    }
-}
-void uart_print_interrupt(const char *string)
-{
-    size_t i = 0;
-    for (i = 0; i < strlen(string); i++) {
-        uart_putchar_interrupt(string[i]);
+        _putchar('\r');
     }
 }
 

--- a/Src/drivers/uart.h
+++ b/Src/drivers/uart.h
@@ -4,4 +4,9 @@
 void uart_init(void);
 void uart_putchar_polling(char c);
 void _putchar(char c);
+
+// to be called only by assert handler
+void uart_init_assert(void);
+void uart_trace_assert(const char *string);
+
 #endif // UART_H

--- a/Src/drivers/uart.h
+++ b/Src/drivers/uart.h
@@ -3,6 +3,5 @@
 /*Uart driver to print messages to the terminal to aid in debugging*/
 void uart_init(void);
 void uart_putchar_polling(char c);
-void uart_putchar_interrupt(char c);
-void uart_print_interrupt(const char *string);
+void _putchar(char c);
 #endif // UART_H

--- a/Src/test/test.c
+++ b/Src/test/test.c
@@ -1,6 +1,7 @@
 #include "../drivers/io.h"
 #include "../drivers/mcu_init.h"
 #include "../common/assert_handler.h"
+#include "../common/trace.h"
 #include "../drivers/led.h"
 #include "../common/defines.h"
 #include "../drivers/uart.h"
@@ -46,7 +47,23 @@ static void test_uart_interrupt(void)
     uart_init();
     volatile int j;
     while (1) {
-        uart_print_interrupt("hello boy\n");
+        // printf("Hello boy %d\n", 20);
+        _putchar('h');
+        _putchar('h');
+        _putchar('h');
+        _putchar('h');
+        _putchar('\n');
+        BUSY_WAIT_ms(60);
+    }
+}
+SUPPRESS_UNUSED
+static void test_trace(void)
+{
+    test_setup();
+    trace_init();
+    volatile int j;
+    while (1) {
+        TRACE("TEST TRACE %d", 1);
         BUSY_WAIT_ms(60);
     }
 }

--- a/external/printf_config.h
+++ b/external/printf_config.h
@@ -1,0 +1,11 @@
+#ifndef PRINTF_CONFIG_H
+#define PRINTF_CONFIG_H
+
+// disable unused options in the printf implementation to save FLASH space
+// printf_config.h file required for the action to work
+#define PRINTF_DISABLE_SUPPORT_FLOAT
+#define PRINTF_DISABLE_SUPPORT_EXPONENTIAL
+#define PRINTF_DISABLE_SUPPORT_PTRDIFF_T
+#define PRINTF_DISABLE_SUPPORT_LONG_LONG
+
+#endif // PRINTF_CONFIG_H


### PR DESCRIPTION
Implemented the external printf functionality by changing the uart interrupt function name to the required _putchar function name for the printf library. Included a header file in the printf folder to disable uneeded functionalities to save space.
Created a TRACE macro to call the printf function, with potential functionality to disable all traces. The TRACE macro was tested with a test_trace test function.

The macro is called as below
e.g. TRACE(fmt, args) -> TRACE("TRACE TEST", 2025)