### PR TITLE
fix: Ring buffer

### DIFF
--- a/Src/common/ring_buffer.c
+++ b/Src/common/ring_buffer.c
@@ -18,10 +18,6 @@ uint8_t ring_buffer_get(struct ring_buffer *rb)
     if (rb->tail == rb->size) {
         rb->tail = 0;
     }
-    // if ring buffer full 1+head == tail make more space in buffer and omit oldest element
-    if (rb->head == rb->tail) {
-        rb->tail++;
-    }
     return buffer_val;
 }
 uint8_t ring_buffer_peek(const struct ring_buffer *rb)


### PR DESCRIPTION
fixed ring buffer issue causing UART to print sporadically, by removing an unecessary block of code.