### PR TITLE
feat(driver): ADC Driver

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,7 @@ C_SOURCES_WITH_HEADERS = \
 	Src/drivers/ir_remote.c \
 	Src/drivers/pwm.c \
 	Src/drivers/tb6612fng.c \
+	Src/drivers/adc.c \
 	Src/common/ring_buffer.c \
 	Src/common/assert_handler.c \
 	Src/common/trace.c \

--- a/Src/drivers/adc.c
+++ b/Src/drivers/adc.c
@@ -1,0 +1,235 @@
+#include "adc.h"
+#include "assert_handler.h"
+#include "io.h"
+#include "defines.h"
+#include "stm32l4xx.h"
+#include <stdbool.h>
+static bool initialized = false;
+static io_e *adc_pins;
+static uint8_t adc_pins_arr_size;
+static uint8_t adc_channels[] = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 };
+static volatile adc_channel_values adc_channel_data;
+static volatile adc_channel_values adc_channel_data_cache;
+static uint8_t dma_data_cnt = ADC_CHANNEL_CNT;
+static uint8_t adc_sequence_scan_length = 0xF;
+static volatile uint32_t *adc2_seq_regs[4] = {
+    [ADC2_SQR_1] = &ADC2->SQR1,
+    [ADC2_SQR_2] = &ADC2->SQR2,
+    [ADC2_SQR_3] = &ADC2->SQR3,
+    [ADC2_SQR_4] = &ADC2->SQR4,
+};
+
+static void adc_set_chs_sample_time()
+{
+    for (uint8_t channel = 0; channel < ARRAY_SIZE(adc_channels); channel++) {
+        if (adc_channels[channel] < 10) {
+            ADC2->SMPR1 &= ~(0x7 << (adc_channels[channel] * 3));
+            ADC2->SMPR1 |= (0x7 << (adc_channels[channel] * 3));
+        } else {
+            ADC2->SMPR2 &= ~(0x7 << ((adc_channels[channel] - 10) * 3));
+            ADC2->SMPR2 |= (0x7 << ((adc_channels[channel] - 10) * 3));
+        }
+    }
+}
+
+static void adc_set_channel_sequences()
+{
+    // tell the ADC that 16 conversations will take place,
+    // enables scan mode
+    ADC2->SQR1 &= ~0xF;
+    ADC2->SQR1 |= adc_sequence_scan_length;
+    // set each channel as a sequence in the SQR regsiters 1-4
+    for (uint8_t channel = 0; channel < ARRAY_SIZE(adc_channels); channel++) {
+        const uint8_t adc_seq_idx = adc_channels[channel] / 5;
+        uint8_t adc_channel = adc_channels[channel];
+        // each register after SQR1 has its LSB as a multiple of 5
+        if (adc_channels[channel] > 4) {
+            adc_channel = adc_channels[channel] - (5 * adc_seq_idx);
+        }
+        *adc2_seq_regs[adc_seq_idx] &= ~(0x1F << (6 * (adc_channel)));
+        *adc2_seq_regs[adc_seq_idx] |= (adc_channels[channel] << (6 * adc_channel));
+
+        // if (adc_channels[channel] < 4) {
+        //     ADC2->SQR1 &= ~(0x1F << (6 * (adc_channels[channel])));
+        //     ADC2->SQR1 |= (adc_channels[channel] << (6 * adc_channels[channel]));
+        // } else if (adc_channels[channel] > 4) {
+        //     ADC2->SQR1 &= ~(0x1F << (6 * (adc_channels[channel])));
+        //     ADC2->SQR1 |= (adc_channels[channel] << (6 * adc_channels[channel]));
+        // }
+        // if (adc_channels[channel] < 4) {
+        //     ADC2->SQR1 &= ~(0x1F << (6 * (adc_channels[channel])));
+        //     ADC2->SQR1 |= (adc_channels[channel] << (6 * adc_channels[channel]));
+        // }
+    }
+}
+
+static void dma_init(void)
+{
+    RCC->AHB1ENR |= 0x1 << 1; // DMA1 clock
+    /* set the peripheral adc_pins_arr_size, ADC data register is 32 bits but converts to 12 bits so
+     * 16 is enough set the memory adc_pins_arr_size, adc_pins_arr_size of the array is 16 bits*/
+    DMA2_Channel4->CCR &= ~((0x3 << 8) | (0x3 << 10));
+    DMA2_Channel4->CCR |= (0x1 << 8) | (0x1 << 10);
+
+    DMA2_Channel4->CCR &= ~(0x1 << 4); // set data transfer direction, reading from peripheral ADC
+
+    DMA2_Channel4->CNDTR = dma_data_cnt; // Set the number of data to transfer, 4 Line senaors
+    DMA2_Channel4->CMAR =
+        (uint32_t)adc_channel_data; // set the DMA memory address to the adc data array
+    DMA2_Channel4->CPAR =
+        (uint32_t)&ADC2->DR; // set the peripheral address to the ADC data register
+    /* enable memory address increment mode
+     * enable circular mode mode
+     * enable DMA*/
+    DMA2_Channel4->CCR |= (0x1 << 7) | (0x1 << 5) | 0x1;
+}
+static inline void adc_start_conversion(void)
+{
+    ADC2->CR |= 0x1 << 2; // start ADC conversion
+}
+
+void adc_init(void)
+{
+    ASSERT(!initialized);
+    adc_pins = get_io_adc_pins(&adc_pins_arr_size);
+    // Clocks
+    RCC->AHB2ENR |= 0x1 << 13; // adc clock
+    RCC->CCIPR &= ~(0x3 << 28); // set ADC clock source to PLLSAI1R
+    RCC->CCIPR |= (0x1 << 28); // set ADC clock source to PLLSAI1R
+    ADC123_COMMON->CCR &= ~(0x3 << 16);
+    ADC123_COMMON->CCR &= ~(0xF << 18);
+    ADC123_COMMON->CCR |= (0x4 << 18); // reduce clock rate for ADC
+    // DMA
+    dma_init();
+    // ADC
+    /*check to see if ADC is enabled, if it is set ADDIS to disable ADC*/
+    if (ADC2->CR & (0x1)) {
+        ADC2->CR |= 0x1 << 1;
+        while (ADC2->CR & (0x1))
+            ;
+    }
+    /*Exit deep power mode by setting the DEEPPWD bit to 0 first, as ADC is by default in deep power
+     * down mode */
+    ADC2->CR &= ~(0x1 << 29);
+    /* enable the ADC voltage regulator ADVREGEN, this should be enabled before calibrating or
+     enabling ADC */
+    ADC2->CR |= 0x1 << 28;
+    /*wait for startup timer ~20us after configureing DEEPPWD and ADVREGEN
+    volatile so complier doesnt optimize the delay away*/
+    for (volatile int i = 0; i < 15000; i++)
+        ;
+
+    // calibrate ADC2
+    // use ADC CAL define to avaoid cpp bit shift error
+    ADC2->CR |= ADC_CR_ADCAL;
+    while (ADC2->CR & (ADC_CR_ADCAL))
+        ;
+    adc_set_chs_sample_time(); // set sampling rate for each channel
+    adc_set_channel_sequences();
+
+    // enable Overrun mode
+    // enable continious mode for ADC
+    // enable DMA circular mode for ADC
+    // enable DMA for ADC
+    ADC1->CFGR = 0;
+    ADC1->CFGR |= (0x1 << 12);
+    ADC2->CFGR |= (0x1 << 13) | (0x1 << 1) | 0x1;
+    ADC2->IER |= 0x1 << 3; // ADC enbale end of sequence interrupt
+    NVIC_EnableIRQ(ADC1_2_IRQn); // enable ADC 1 and 2 global interrupt
+
+    ADC2->CR |= 0x1; // enable ADC
+    while (!(ADC2->ISR & 0x1))
+        ;
+    adc_start_conversion();
+
+    initialized = true;
+}
+
+void ADC1_2_IRQHandler(void)
+{
+    /*Check the EOSS flag and EOS register to see if a sequence of conversions has ended and the
+     * interrupt is enabled*/
+    if ((ADC2->ISR & (0x1 << 3)) && (ADC2->IER & (0x1 << 3))) {
+        /*copy ADC channel data from DMA output memeory location into a cache array
+         * do this to not interfer with the DMA output memory location
+         */
+        for (uint8_t channel = 0; channel < dma_data_cnt; channel++) {
+            adc_channel_data_cache[channel] = adc_channel_data[channel];
+        }
+        // clear the flag after handling the interrupt
+        ADC2->ISR |= (0x1 << 3);
+    }
+}
+
+SUPPRESS_UNUSED
+void adc_read_channel_values(adc_channel_values ch_vals)
+
+{
+    /* disable all interrupts during copying to prevent any data corruptions from another set of
+     * channel readings*/
+    __disable_irq();
+    for (uint8_t i = 0; i < adc_pins_arr_size; i++) {
+        const uint8_t channel_idx = io_adc_idx((io_ports_e)adc_pins[i]);
+        ch_vals[channel_idx] = adc_channel_data_cache[channel_idx];
+    }
+    __enable_irq();
+}
+
+SUPPRESS_UNUSED
+// to test adc function of a single pin using polling
+void adc_single_init(void)
+{
+
+    RCC->AHB2ENR |= 0x1 << 13; // adc clock
+    RCC->CCIPR &= ~(0x3 << 28); // set ADC clock source to PLLSAI1R
+    RCC->CCIPR |= (0x1 << 28); // set ADC clock source to PLLSAI1R
+    ADC123_COMMON->CCR &= ~(0x3 << 16);
+    ADC123_COMMON->CCR &= ~(0xF << 18);
+    ADC123_COMMON->CCR |= (0x4 << 18); // reduce clock rate for ADC
+    // GPIOA->ASCR |= 0x1;
+    /*check to see if ADC is enabled, if it is set ADDIS to disable ADC*/
+    if (ADC1->CR & (0x1)) {
+        ADC1->CR |= 0x1 << 1;
+        while (ADC1->CR & (0x1))
+            ;
+    }
+    // ADC1->CR = 0;
+    /*Exit deep power mode by setting the DEEPPWD bit to 0 first, as ADC is by default in deep power
+     * down mode */
+    ADC1->CR &= ~(0x1 << 29);
+    /* enable the ADC voltage regulator ADVREGEN, this should be enabled before calibrating or
+     enabling ADC */
+    ADC1->CR |= 0x1 << 28;
+    /*wait for startup timer ~20us after configureing DEEPPWD and ADVREGEN
+    volatile so complier doesnt optimize the delay away*/
+    for (volatile int i = 0; i < 20000; i++)
+        ;
+
+    // calibrate ADC2
+    // use ADC CAL define to avaoid cpp bit shift error
+    ADC2->CR |= ADC_CR_ADCAL;
+    while (ADC2->CR & (ADC_CR_ADCAL))
+        ;
+
+    ADC1->CFGR = 0;
+    ADC1->CFGR |= ADC_CFGR_OVRMOD;
+
+    ADC1->SMPR1 &= ~(0x7 << (15));
+    ADC1->SMPR1 |= (0x7 << 15);
+    ADC1->SQR1 &= ~(0x1F << (6));
+    ADC1->SQR1 |= (5 << (6));
+
+    ADC1->CR |= 0x1; // enable ADC
+    while (!(ADC1->ISR & 0x1))
+        ;
+}
+SUPPRESS_UNUSED
+void adc_read_value(uint32_t *ch_vals)
+{
+    ADC1->ISR |= ADC_ISR_EOC;
+
+    ADC1->CR |= 0x1 << 2;
+    while (!(ADC1->ISR & ADC_ISR_EOC))
+        ;
+    *ch_vals = ADC1->DR;
+}

--- a/Src/drivers/adc.h
+++ b/Src/drivers/adc.h
@@ -1,0 +1,41 @@
+#ifndef ADC_H
+#define ADC_H
+#include <stdint.h>
+// Using ADC2 and it has 16 channels
+
+#define ADC_CHANNEL_CNT (16)
+// driver for getting the Analog line sensor voltage
+typedef enum
+{
+    ADC2_SQR_1,
+    ADC2_SQR_2,
+    ADC2_SQR_3,
+    ADC2_SQR_4,
+} adc2_seq_regs_e;
+
+typedef enum
+{
+    ADC2_IN1,
+    ADC2_IN2,
+    ADC2_IN3,
+    ADC2_IN4,
+    ADC2_IN5,
+    ADC2_IN6,
+    ADC2_IN7,
+    ADC2_IN8,
+    ADC2_IN9,
+    ADC2_IN10,
+    ADC2_IN11,
+    ADC2_IN12,
+    ADC2_IN13,
+    ADC2_IN14,
+    ADC2_IN15,
+    ADC2_IN16,
+} adc2_chs_e;
+typedef uint16_t adc_channel_values[ADC_CHANNEL_CNT];
+void adc_init(void);
+void adc_single_init(void);
+// ch_vals after typdef -> uint16_t ch_vals[16] so already passed as a pointer after typdef
+void adc_read_channel_values(adc_channel_values ch_vals);
+void adc_read_value(uint32_t *ch_vals);
+#endif // ADC_H

--- a/Src/drivers/io.h
+++ b/Src/drivers/io.h
@@ -1,6 +1,8 @@
 #ifndef IO_H
 #define IO_H
 #include "stdbool.h"
+#include <stdint.h>
+
 // ENUMS
 typedef enum
 {
@@ -59,7 +61,7 @@ typedef enum
 typedef enum
 {
     // PA
-    IO_LD_FRONT_LEFT = IO_PA_0,
+    IO_LD_FRONT_LEFT = IO_PA_0, // LD-> Line detect
     IO_LD_BACK_LEFT = IO_PA_1,
     IO_UNUSED_1 = IO_PA_2,
     IO_UNUSED_2 = IO_PA_3,
@@ -222,6 +224,9 @@ void io_set_output_speed(io_e io, io_ouput_speed_e speed);
 void io_set_AF(io_e io, io_af_e af);
 void io_set_output(io_e io, io_out_e out);
 io_in_e io_get_input(io_e io);
+io_e *get_io_adc_pins(uint8_t *size);
+uint8_t io_adc_idx(io_ports_e io);
+void io_set_analog_switch_crl_reg(io_e io);
 
 typedef void (*isr_function)(void);
 void io_interrupt_clock_init(void);

--- a/Src/drivers/mcu_init.c
+++ b/Src/drivers/mcu_init.c
@@ -30,6 +30,24 @@ static void init_clocks()
     while (!(RCC->CR & (0x1 << 25)))
         ;
 
+    // turn PLLSAI1 off
+    RCC->CR &= ~(0x1 << 26);
+    while ((RCC->CR & (0x1 << 27)))
+        ;
+    /*enable PLLSAI1R as it it used as the ADC clock
+     * left at default divider2 */
+
+    RCC->PLLSAI1CFGR &= ~(0x3 << 25); // R
+    RCC->PLLSAI1CFGR &= ~(0x3 << 21); // Q
+    RCC->PLLSAI1CFGR &= ~(0x1 << 17); // P
+    RCC->PLLSAI1CFGR &= ~(0x7F << 8); // N
+    RCC->PLLSAI1CFGR |= (0x7 << 8); // N
+    RCC->PLLSAI1CFGR |= 0x1 << 24;
+    // turn PLLSAI1 on
+    RCC->CR |= 0x1 << 26;
+    while (!(RCC->CR & (0x1 << 27)))
+        ;
+
     // set sys clock as PLL
     RCC->CFGR &= ~0x3;
     RCC->CFGR = (RCC->CFGR & ~0x3) | 0x3;

--- a/Src/test/test.c
+++ b/Src/test/test.c
@@ -9,6 +9,7 @@
 #include "../drivers/pwm.h"
 #include "../drivers/tb6612fng.h"
 #include "../app/drive.h"
+#include "../drivers/adc.h"
 static const io_e io_pins[] = { IO_I2C_SDA,           IO_I2C_SCL,
                                 IO_LD_FRONT_LEFT,     IO_LD_BACK_LEFT,
                                 IO_UART_TX,           IO_UART_RX,
@@ -298,6 +299,38 @@ void test_stop_motors_assert(void)
     ASSERT(0);
     while (0)
         ;
+}
+SUPPRESS_UNUSED
+void test_adc(void)
+{
+    test_setup();
+    trace_init();
+    adc_init();
+    volatile int j;
+    adc_channel_values adc_channel_data = { 0 };
+    while (1) {
+        adc_read_channel_values(adc_channel_data);
+        // channel 1 -> index 0
+        // using (i+1) to match actual ADC channel structure, i.e. 1-16 rather than 0-15
+        for (uint8_t i = 0; i < ADC_CHANNEL_CNT; i++) {
+            TRACE("ADC CHANNEL %u | VAL : %u\n", i, adc_channel_data[i]);
+        }
+        BUSY_WAIT_ms(300);
+    };
+}
+SUPPRESS_UNUSED
+void test_adc_single(void)
+{
+    test_setup();
+    trace_init();
+    adc_single_init();
+    volatile int j;
+    uint32_t value;
+    while (1) {
+        adc_read_value(&value);
+        TRACE("ADC CHANNEL %u | VAL : %u", 15, value);
+        BUSY_WAIT_ms(500);
+    };
 }
 int main()
 {


### PR DESCRIPTION
ADC driver for line sensor making use of continous ADC along wtih DMA and an ADC interrupt. For the driver all 16 channels of ADC2 are read for adc values, Direct Memory Access, DMA, is used to copy the adc values from the ADC2 data reg to a location in memory. DMA is used in the driver to reduce CPU loading during operation. A final memory location is then used to store the adc values for use, by copying the adc values from memory location 1 in an ADC interrupt to the final location 2, this is done to avoid corruption of location 1 if it is read from directly.
ADC functions to test a single ADC channel using polling is also implemented in the driver for ADC testing. The ADC driver was tested by reading 0 and 3.3V adc outputs when the corresponding adc pins were pulled to those voltage levels.