### PR TITLE
feat(driver): I2C driver for VL530X sensor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,7 @@ C_SOURCES_WITH_HEADERS = \
 	Src/drivers/tb6612fng.c \
 	Src/drivers/adc.c \
 	Src/drivers/qre1113.c \
+	Src/drivers/i2c.c \
 	Src/common/ring_buffer.c \
 	Src/common/assert_handler.c \
 	Src/common/trace.c \

--- a/Src/drivers/i2c.c
+++ b/Src/drivers/i2c.c
@@ -1,0 +1,232 @@
+#include "i2c.h"
+#include "io.h"
+#include "stm32l4xx.h"
+#include "assert_handler.h"
+#include <stdbool.h>
+#define I2C_DEFAULT_SLAVE_ADDR (0x29)
+#define RETRY_TIMEOUT (UINT16_MAX)
+static const struct io_config i2c_config = { .mode = IO_MODE_ALTFN,
+                                             .pupd = IO_NO_PUPD,
+                                             .speed = IO_SPEED_VERY_HIGH,
+                                             .type = IO_TYPE_OD,
+                                             .af = IO_AF_4 };
+static bool intitialized = false;
+static uint8_t vl53l0x_slave_address = 0;
+void i2c_init(void)
+{
+    ASSERT(!intitialized);
+    // check that pin config is correct
+    struct io_config current_config;
+    io_get_io_config(IO_I2C_SCL, &current_config);
+    ASSERT(io_compare_io_config(&current_config, &i2c_config));
+    io_get_io_config(IO_I2C_SDA, &current_config);
+    ASSERT(io_compare_io_config(&current_config, &i2c_config));
+
+    RCC->APB1ENR1 |= 0x1 << 23;
+    I2C3->CR1 &= ~0x1; // clears PE in CR1 reg to being intitialization
+    I2C3->TIMINGR = 0x10D19CE4; // TIMINGR generated using stm32cubemx and default I2C speed
+                                // settings i.e. standard mode
+    I2C3->CR1 &= ~(0x1 << 17); // clear the bit to enable clock stretching
+    I2C3->CR1 |= 0x1; // enables PE in CR1 reg to being intitialization
+
+    intitialized = true;
+}
+void i2c_set_slave_addr(uint8_t addr)
+{
+    vl53l0x_slave_address = addr;
+}
+static inline void i2c_set_start_condition(void)
+{
+    I2C3->CR2 |= (0x1 << 13); // set start condition
+}
+static inline void i2c_send_tx_byte(uint8_t byte)
+{
+    I2C3->TXDR = byte;
+}
+static inline uint8_t i2c_recieve_rx_byte(void)
+{
+    return I2C3->RXDR;
+}
+
+static void i2c_configure(uint8_t data_size, uint8_t addr_size, i2c_state_e state)
+{
+    I2C3->CR2 &= ~0x3FF; // clear the slave address
+    I2C3->CR2 |= vl53l0x_slave_address << 1; // write the slave address
+    I2C3->CR2 &= ~(0xFF << 16); // clear NBYTES
+    uint16_t size;
+    switch (state) {
+    case I2C_SEND:
+        size = data_size + addr_size;
+        break;
+
+    default:
+        size = data_size;
+        break;
+    }
+    I2C3->CR2 |=
+        size << 16; // set NBYTES number of bytes to be sent, reg of slave to be written to and data
+    I2C3->CR2 |= (0x1 << 25); // set AUTOEND mode
+}
+static i2c_result_code_e i2c_tx_flag_wait(void)
+{
+    uint16_t retries = RETRY_TIMEOUT;
+
+    // wait for TXDR to be empty
+    while (!(I2C3->ISR & 0x1 << 1) && --retries)
+        ;
+    if (I2C3->ISR & 0x1 << 4) { // check for a NACK after transsimision
+        I2C3->ICR |= 0x1 << 4; // clear NACKCF bit
+        return I2C_RESULT_ERROR_TX;
+    }
+    if (retries == 0) {
+        return I2C_RESULT_ERROR_TIMEOUT;
+    }
+    return I2C_RESULT_OK;
+}
+static i2c_result_code_e i2c_rx_flag_wait(void)
+{
+    uint16_t retries = RETRY_TIMEOUT;
+
+    // wait for RXDR to be empty
+    while (!(I2C3->ISR & 0x1 << 2) && --retries)
+        ;
+    if (I2C3->ISR & 0x1 << 4) { // check for a NACK after transsimision
+        I2C3->ICR |= 0x1 << 4; // clear NACKCF bit
+        return I2C_RESULT_ERROR_RX;
+    }
+    if (retries == 0) {
+        return I2C_RESULT_ERROR_TIMEOUT;
+    }
+    return I2C_RESULT_OK;
+}
+static i2c_result_code_e i2c_start_tx_transfer(const uint8_t *vl53l0x_memory_addr,
+                                               uint8_t addr_size)
+{
+    I2C3->CR2 &= ~(0x1 << 10); // set to write direction
+    i2c_set_start_condition();
+
+    // address could be 8, 16 or 32 bytes
+    for (uint8_t i = 0; i < addr_size; i++) {
+        i2c_result_code_e result = i2c_tx_flag_wait();
+        if (result) {
+            return result;
+        }
+        i2c_send_tx_byte(vl53l0x_memory_addr[i]);
+    }
+    return I2C_RESULT_OK; // no errors and o0 in enum so wont trigger if statment for return
+}
+static i2c_result_code_e i2c_start_rx_transfer(const uint8_t *vl53l0x_memory_addr,
+                                               uint8_t addr_size)
+{
+    /* Not using AUTOEND here because it would generate a STOP after sending the address to be read
+     * Using Manual mode, (AUTOEND = 0) allows for no automatic generation of STOP
+     * so you can send the address and then restart I2C to read from the sensor*/
+
+    I2C3->CR2 = 0;
+    // I2C3->CR2 &= ~0x3FF; // clear the slave address
+    I2C3->CR2 |= vl53l0x_slave_address << 1; // write the slave address
+    // I2C3->CR2 &= ~(0xFF << 16); // clear NBYTES
+
+    I2C3->CR2 |= addr_size
+        << 16; // set NBYTES number of bytes to be sent, reg of slave to be written to and data
+    I2C3->CR2 &= ~(0x1 << 10); // set to write direction
+    i2c_set_start_condition();
+
+    // address could be 8, 16 or 32 bytes
+    for (uint8_t i = 0; i < addr_size; i++) {
+        i2c_result_code_e result = i2c_tx_flag_wait();
+        if (result) {
+            return result;
+        }
+        i2c_send_tx_byte(vl53l0x_memory_addr[i]);
+    }
+    // ensure address transfer completed succefully before starting the next START condition for
+    // reading bytes
+    while (!(I2C3->ISR & (0x1 << 6)))
+        ;
+    return I2C_RESULT_OK; // no errors and 0 in enum so wont trigger if statment for return
+}
+static void i2c_start_rx_byte_read(void)
+{
+    I2C3->CR2 |= (0x1 << 10); // set to read direction
+    i2c_set_start_condition();
+}
+i2c_result_code_e i2c_read(const uint8_t *vl53l0x_memory_addr, uint8_t addr_size, uint8_t *data,
+                           uint8_t data_size)
+{
+    ASSERT(vl53l0x_memory_addr);
+    ASSERT(addr_size > 0);
+    ASSERT(data);
+    ASSERT(data_size > 0);
+    // check if bus is busy
+    while ((I2C3->ISR & 0x1 << 15))
+        ;
+    i2c_result_code_e result = i2c_start_rx_transfer(vl53l0x_memory_addr, addr_size);
+    if (result) {
+        return result;
+    }
+
+    i2c_configure(data_size, addr_size, I2C_RECEIVE);
+    i2c_start_rx_byte_read(); // restart i2c to read bytes from slave
+
+    // Data is received MSB first, in STM32 the LSB is at 0
+    // so put the MSB at the data_size - 1 pos
+    // cppcheck-suppress unsignedLessThanZero
+    for (uint16_t i = data_size - 1; 0 >= i; i--) {
+        result = i2c_rx_flag_wait();
+        if (result) {
+            return result;
+        }
+        data[i] = i2c_recieve_rx_byte();
+    }
+    // wait for STOP detection to be set after NBYTES is completed
+    while (!(I2C3->ISR & (0x1 << 5)))
+        ;
+    I2C3->ICR |= 0x1 << 5; // clear the STOP detection flag in ISR
+    return result;
+};
+i2c_result_code_e i2c_write(const uint8_t *vl53l0x_memory_addr, uint8_t addr_size,
+                            const uint8_t *data, uint8_t data_size)
+{
+    ASSERT(vl53l0x_memory_addr);
+    ASSERT(addr_size > 0);
+    ASSERT(data);
+    ASSERT(data_size > 0);
+    while ((I2C3->ISR & 0x1 << 15))
+        ; // check if bus is busy
+    i2c_configure(data_size, addr_size, I2C_SEND);
+    // start transmission and send vl53l9x memory location been written to
+    i2c_result_code_e result = i2c_start_tx_transfer(vl53l0x_memory_addr, addr_size);
+    if (result) {
+        return result;
+    }
+
+    // sending data from MSB to LSB expected by vl53l0x
+    for (uint16_t i = 0; i < data_size; i++) {
+        result = i2c_tx_flag_wait();
+        if (result) {
+            return result;
+        }
+        i2c_send_tx_byte(data[i]);
+    } // wait for STOP detection to be set after NBYTES is completed
+    while (!(I2C3->ISR & (0x1 << 5)))
+        ;
+    I2C3->ICR |= 0x1 << 5; // clear the STOP detection flag in ISR
+    return result;
+};
+i2c_result_code_e i2c_read_addr8_data8(uint8_t addr, uint8_t *data)
+{
+    return i2c_read(&addr, 1, data, 1); // 1 -> 1 byte
+}
+i2c_result_code_e i2c_read_addr8_data16(uint8_t addr, uint16_t *data)
+{
+    return i2c_read(&addr, 1, (uint8_t *)data, 2);
+}
+i2c_result_code_e i2c_read_addr8_data32(uint8_t addr, uint32_t *data)
+{
+    return i2c_read(&addr, 1, (uint8_t *)data, 4);
+}
+i2c_result_code_e i2c_write_addr8_data8(uint8_t addr, const uint8_t *data)
+{
+    return i2c_write(&addr, 1, data, 1);
+}

--- a/Src/drivers/i2c.h
+++ b/Src/drivers/i2c.h
@@ -1,0 +1,35 @@
+#ifndef I2C_H
+#define I2C_H
+#include <stdint.h>
+// driver for the VL53L0X sensor used to detect an enemy through polling
+typedef enum
+{
+    I2C_SEND,
+    I2C_RECEIVE
+} i2c_state_e;
+typedef enum
+{
+    I2C_RESULT_OK,
+    I2C_RESULT_ERROR_START,
+    I2C_RESULT_ERROR_TX,
+    I2C_RESULT_ERROR_RX,
+    I2C_RESULT_ERROR_STOP,
+    I2C_RESULT_ERROR_TIMEOUT,
+} i2c_result_code_e;
+
+void i2c_init(void);
+void i2c_set_slave_addr(
+    uint8_t addr); // to switch device i2c address when writing to one of the sensors
+// passing the addr as a byte array because the addreess could be 8, 16 0r 32 bits
+// the functions send data from MSB to LSB expected by vl53l0x
+
+i2c_result_code_e i2c_read(const uint8_t *vl53l0x_memory_addr, uint8_t addr_size, uint8_t *data,
+                           uint8_t data_size);
+i2c_result_code_e i2c_write(const uint8_t *vl53l0x_memory_addr, uint8_t addr_size,
+                            const uint8_t *data, uint8_t data_size);
+
+i2c_result_code_e i2c_read_addr8_data8(uint8_t addr, uint8_t *data);
+i2c_result_code_e i2c_read_addr8_data16(uint8_t addr, uint16_t *data);
+i2c_result_code_e i2c_read_addr8_data32(uint8_t addr, uint32_t *data);
+i2c_result_code_e i2c_write_addr8_data8(uint8_t addr, const uint8_t *data);
+#endif // I2C_H

--- a/Src/test/test.c
+++ b/Src/test/test.c
@@ -12,6 +12,7 @@
 #include "../app/line.h"
 #include "../drivers/adc.h"
 #include "../drivers/qre1113.h"
+#include "../drivers/i2c.h"
 static const io_e io_pins[] = { IO_I2C_SDA,           IO_I2C_SCL,
                                 IO_LD_FRONT_LEFT,     IO_LD_BACK_LEFT,
                                 IO_UART_TX,           IO_UART_RX,
@@ -402,6 +403,54 @@ static void test_line_detect(void)
         TRACE("LINE POS: %s", line_to_string(get_line_position()));
         BUSY_WAIT_ms(200);
     };
+}
+SUPPRESS_UNUSED
+static void test_i2c(void)
+{
+    test_setup();
+    trace_init();
+    i2c_init();
+    volatile int j;
+    uint8_t vl53l0x_product_id = 0;
+    uint8_t write_val = 0xAB;
+    uint8_t vl53l0x_read_result = 0;
+    // have to set XHSUT Pin HIGH for VL53L0X to pull the sensor from standby mode
+    io_set_output(IO_XSHUT_FRONT, IO_OUT_HIGH);
+    // set the default slave address of the sensor
+    i2c_set_slave_addr(0x29);
+    // wait a bit for sensor to leave standby
+    BUSY_WAIT_ms(200);
+
+    while (1) {
+        i2c_result_code_e result = i2c_read_addr8_data8(0xC0, &vl53l0x_product_id);
+        if (result) {
+            TRACE("I2C result error: %d", result);
+        } else {
+            if (vl53l0x_product_id == 0xEE) {
+                TRACE("Valid VL53L0X PRODUCT ID (0xEE): %#X", vl53l0x_product_id);
+            } else {
+                TRACE("Invalid VL53L0X PRODUCT ID (expected 0xEE): %#X", vl53l0x_product_id);
+            }
+        }
+        BUSY_WAIT_ms(200);
+        result = i2c_write_addr8_data8(0x01, &write_val);
+        if (result) {
+            TRACE("I2C result error: %d", result);
+        }
+        result = i2c_read_addr8_data8(0x01, &vl53l0x_read_result);
+        if (result) {
+            TRACE("I2C result error: %d", result);
+        } else {
+            if (vl53l0x_read_result == write_val) {
+                TRACE("Valid VL53L0X WRITE TEST: Written %#X, Read %#X", write_val,
+                      vl53l0x_read_result);
+            } else {
+                TRACE("Invalid VL53L0X WRITE TEST: Written %#X, Read %#X", write_val,
+                      vl53l0x_read_result);
+            }
+        }
+        BUSY_WAIT_ms(200);
+    }
 }
 int main()
 {


### PR DESCRIPTION
I2C driver for VL530X sensor using polling, since use case for the sensor does not require interrupts. The driver includes i2c read and write functionality. The driver works for multi byte address and data applications, but 1-3 bytes will be the range utilized for the this project when interacting with the VL530X sensor. The test function for the driver includes reading and writing to and from writiable/readable addresses of VL530X sensor.